### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend_build.yml
+++ b/.github/workflows/frontend_build.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
 
 name: Node.js CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/demortes/alfred2/security/code-scanning/1](https://github.com/demortes/alfred2/security/code-scanning/1)

To fix this issue and adhere to the principle of least privilege, the workflow should declare a `permissions` block either at the workflow level (which applies to all jobs unless overridden) or at the individual job level. Since the current workflow is only performing build and test steps (installing dependencies, running npm commands), the minimal required permission is `contents: read`. This should be specified near the top of the YAML file, just below the `name` declaration and before the `on` block. No additional permissions should be granted unless specifically needed by the workflow steps.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to explicitly grant read access to repository contents.
  * No changes to triggers, jobs, or steps; build behavior remains unchanged.
  * No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->